### PR TITLE
Fix setting pool and filesystem config items

### DIFF
--- a/roles/zfs_pool/tasks/_zfs_pools.yml
+++ b/roles/zfs_pool/tasks/_zfs_pools.yml
@@ -19,7 +19,7 @@
 
 - name: "Set zfs configs"
   ansible.builtin.command: "zfs set {{ pool_item.key }}={{ pool_item.value }} {{ _zfs_name }}"
-  loop: "{{ _zfs_pool_configs | dict2items }}"
+  loop: "{{ _zfs_fs_configs | dict2items }}"
   loop_control:
     loop_var: pool_item
   tags:
@@ -27,7 +27,7 @@
 
 - name: "Set pool configs"
   ansible.builtin.command: "zpool set {{ pool_item.key }}={{ pool_item.value }} {{ _zfs_name }}"
-  loop: "{{ _zfs_fs_configs | dict2items }}"
+  loop: "{{ _zfs_pool_configs | dict2items }}"
   loop_control:
     loop_var: pool_item
   tags:


### PR DESCRIPTION
Both "Set zfs configs" and "Set pool configs" were looping over the other one's config items.

Adding

```yaml
- role: cloudnull.filesystems.zfs_pool
  zfs_arrays:
    rpool:
      layout: raid0
      drives: "/dev/sda"
      pool_configs:
        autotrim: "on"
```

to my playbook failed with the following error
```
failed: [hrair] (item={'key': 'autotrim', 'value': 'on'}) => {
    "ansible_loop_var": "pool_item",
    "changed": true,
    "cmd": [
        "zfs",
        "set",
        "autotrim=on",
        "rpool"
    ],
    "delta": "0:00:00.004286",
    "end": "2022-12-22 22:06:59.895704",
    "invocation": {
        "module_args": {
            "_raw_params": "zfs set autotrim=on rpool",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "stdin_add_newline": true,
            "strip_empty_ends": true
        }
    },
    "msg": "non-zero return code",
    "pool_item": {
        "key": "autotrim",
        "value": "on"
    },
    "rc": 1,
    "start": "2022-12-22 22:06:59.891418",
    "stderr": "cannot set property for 'rpool': invalid property 'autotrim'",
    "stderr_lines": [
        "cannot set property for 'rpool': invalid property 'autotrim'"
    ],
    "stdout": "",
    "stdout_lines": []
}
```

because the "Set zfs configs" task was looping across `_zfs_pool_configs'. Likewise, "Set pool configs" was looping across `_zfs_fs_configs`.  Exchanging the two variables corrected the problem.

