### PR TITLE
Support creating new pools even when others exist

### DIFF
--- a/roles/zfs_pool/tasks/_zfs_pools.yml
+++ b/roles/zfs_pool/tasks/_zfs_pools.yml
@@ -1,7 +1,8 @@
 ---
 - name: Gather facts about ZFS dataset
-  community.general.zfs_facts:
+  community.general.zpool_facts:
     name: "{{ _zfs_name }}"
+    properties: name
   failed_when: false
 
 - name: "Create pool"
@@ -15,7 +16,7 @@
     zpool create {{ options }} -f {{ _zfs_name }} {{ _zfs_layout }} {{ _zfs_devices | join(' ') }}
     {% endif %}
   when:
-  - ansible_zfs_datasets is undefined
+  - not _zfs_name in ( ansible_zfs_pools | map(attribute='name') )
 
 - name: "Set zfs configs"
   ansible.builtin.command: "zfs set {{ pool_item.key }}={{ pool_item.value }} {{ _zfs_name }}"


### PR DESCRIPTION
My use case is configuring two zpools on a Proxmox machine.

* `rpool` - Root filesystem
* `tank` - Local VM storage

The Proxmox installer creates `rpool`. Then I use Ansible to configure the machine including creating a 2-drive `tank` pool.

The problem is that `_zfs_pools.yml` will not create any pool if any `ansible_zfs_datasets` exist.  I have updated the logic to use `zpool_facts` rather than `zfs_facts` and to create the pool if its name is not found in `ansible_zfs_pools`.

With this change, the following works:
```yaml
    - role: cloudnull.filesystems.zfs_pool
      zfs_arrays:
        # The root pool is configured at installation time, but PVE
        # did not enable autotrim even though /dev/sda is an SSD.
        # According to the commit that added trim support, it is worth
        # enabling autotrim *and* running a scheduled trim.  PVE
        # already handles the scheduled trim.
        #
        # https://github.com/openzfs/zfs/commit/1b939560be5c51deecf875af9dada9d094633bf7
        rpool:
          layout: raid0
          drives: "sda"
          pool_configs:
            autotrim: "on"

        # The tank pool is used for local VM storage
        tank:
          layout: mirror
          drives: [ "sdb", "sdc" ]
```

The `rpool` spec only enables autotrim for the root SSD, which Proxmox does not do and the `tank` spec creates the storage pool, if it does not exist.