### PR TITLE
Skip unchanged zpool properties

### DIFF
--- a/roles/zfs_pool/tasks/_zfs_pools.yml
+++ b/roles/zfs_pool/tasks/_zfs_pools.yml
@@ -2,7 +2,6 @@
 - name: Gather facts about ZFS dataset
   community.general.zpool_facts:
     name: "{{ _zfs_name }}"
-    properties: name
   failed_when: false
 
 - name: "Create pool"
@@ -28,6 +27,8 @@
 
 - name: "Set pool configs"
   ansible.builtin.command: "zpool set {{ pool_item.key }}={{ pool_item.value }} {{ _zfs_name }}"
+  when:
+  - not ( pool_item.value | string ) in ( ansible_zfs_pools | map(attribute=pool_item.key) )
   loop: "{{ _zfs_pool_configs | dict2items }}"
   loop_control:
     loop_var: pool_item


### PR DESCRIPTION
If any properties are specified for a zpool, the module will always report them as changed.  Using my previous example,

```yaml
    - role: cloudnull.filesystems.zfs_pool
      zfs_arrays:
        rpool:
          layout: raid0
          drives: "sda"
          pool_configs:
            autotrim: "on"
```
everytime the playbook runs, Ansible will report `autotrim` as changed, even when it has already been set.

```
TASK [cloudnull.filesystems.zfs_pool : Set pool configs] ***********************
changed: [host] => (item={'key': 'autotrim', 'value': 'on'})
```

With this PR, it will skip it.

```
TASK [cloudnull.filesystems.zfs_pool : Check pool cache] ***********************
skipping: [host]
```

If I add `ashift: 12` to `pool_configs`, only the new property will be reported as changed.

```
TASK [cloudnull.filesystems.zfs_pool : Set pool configs] ***********************
skipping: [host] => (item={'key': 'autotrim', 'value': 'on'}) 
changed: [host] => (item={'key': 'ashift', 'value': 12})
```
If it is run again, both will be skipped and the host will be reported as skipped.
```
TASK [cloudnull.filesystems.zfs_pool : Set pool configs] ***********************
skipping: [host] => (item={'key': 'autotrim', 'value': 'on'}) 
skipping: [host] => (item={'key': 'ashift', 'value': 12}) 
skipping: [host]
```

When I use zfs properties, I may add something similar for them.  The change will be a little more complicated, because the ZFS facts will have to be gathered and the "Set ZFS Configs" possibly moved into a block with it. I'm not submitting it with this, because I don't have a test case just yet.