### PR TITLE
add raid1 check before setting chunk size

### DIFF
--- a/roles/mdadm/tasks/_mdadm_create.yml
+++ b/roles/mdadm/tasks/_mdadm_create.yml
@@ -30,8 +30,7 @@
       yes | mdadm
       --create
       --assume-clean
-      --level={{ outer_item.value.level }}
-      --chunk={{ outer_item.value.chunk | default(256) }}
+      --level={{ outer_item.value.level | lower }} {% if not ((outer_item.value.level | lower) == 'raid1') %} --chunk={{ outer_item.value.chunk | default(256) }} {% endif %}
       --raid-devices={{ outer_item.value.drives | count }}
       /dev/{{ outer_item.key }}
       {{ outer_item.value.drives | join (' ') }}


### PR DESCRIPTION
The chunk size option is not compatible with a raid1, so we need to check if the raid level has been set to raid1 before using this flag.

Signed-off-by: Kevin Carter <kevin.carter@figment.io>