### PR TITLE
feat(format): Add support for bind mounts

### DIFF
--- a/roles/format/defaults/main.yml
+++ b/roles/format/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 format_mount_enabled: true
 format_mount_options: "defaults"
+format_enabled: true

--- a/roles/format/defaults/main.yml
+++ b/roles/format/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 format_mount_enabled: true
 format_mount_options: "defaults"
-format_enabled: true

--- a/roles/format/meta/argument_specs.yml
+++ b/roles/format/meta/argument_specs.yml
@@ -27,6 +27,14 @@ argument_specs:
         choices:
         - true
         - false
+      format_enabled:
+        type: "bool"
+        description: "Enable or disable formating a block device."
+        required: false
+        default: true
+        choices:
+        - true
+        - false
       format_mount_point:
         type: "str"
         description: "Mount point for a given block device."

--- a/roles/format/meta/argument_specs.yml
+++ b/roles/format/meta/argument_specs.yml
@@ -11,6 +11,21 @@ argument_specs:
         type: "str"
         description: "Filesystem used when formatting a block device."
         required: true
+        choices:
+          - btrfs
+          - ext4
+          - ext3
+          - ext2
+          - ext4dev
+          - f2fs
+          - lvm
+          - octfs2
+          - reiserfs
+          - xfs
+          - vfat
+          - swap
+          - ufs
+          - none
       format_device:
         type: "str"
         description: "Block device path that will be formatted."
@@ -22,14 +37,6 @@ argument_specs:
       format_mount_enabled:
         type: "bool"
         description: "Enable or disable mounting a block device."
-        required: false
-        default: true
-        choices:
-        - true
-        - false
-      format_enabled:
-        type: "bool"
-        description: "Enable or disable formating a block device."
         required: false
         default: true
         choices:

--- a/roles/format/tasks/main.yml
+++ b/roles/format/tasks/main.yml
@@ -4,6 +4,8 @@
     fstype: "{{ format_filesystem }}"
     opts: "{{ format_options | default(omit) }}"
     dev: "{{ format_device }}"
+  when:
+    - format_enabled | bool
 
 - name: Mount block
   when:

--- a/roles/format/tasks/main.yml
+++ b/roles/format/tasks/main.yml
@@ -5,7 +5,7 @@
     opts: "{{ format_options | default(omit) }}"
     dev: "{{ format_device }}"
   when:
-    - format_enabled | bool
+    - format_fileystem != "none"
 
 - name: Mount block
   when:


### PR DESCRIPTION
Added a new condition to skip formatting when fstype is set to "none" this way the role will also support bind mounts. 
Also I enhanced the spec file to now include a full list of supported filesyste_type parameters