### PR TITLE
[SECOPS-2289] pin all GitHub Actions to full commit SHAs for supply-chain security #sec

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -3,36 +3,13 @@ on:
 - pull_request
 jobs:
   pre_commit:
-    runs-on: ubuntu-latest
+    uses: figment-networks/figment-github-actions/.github/workflows/pre-commit.yaml@89b46e3bd29417a8c1a9129f0a200f63bf98b7e2
+    with:
+      python_version: ${{ matrix.python_version }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version:
+        python_version:
         - "3.10"
         - "3.11"
         - "3.12"
-    steps:
-    - name: Check out the repo
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Get changed files
-      id: changed-files
-      uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
-    - name: Run Check
-      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
-      with:
-        extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
-    - name: Checks failed, notification
-      if: failure()
-      run: |
-        echo "Tests Failed"
-        echo "Run the following command to identify issues"
-        echo "pre-commit run --files ${{ steps.changed-files.outputs.all_changed_files }}"
-    - name: Upload log artifacts on failure
-      if: failure()
-      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
-      with:
-        name: pre-commit-py${{ matrix.python-version }}
-        path: /home/runner/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,21 +7,21 @@ jobs:
     strategy:
       matrix:
         python-version:
-        - "3.8"
-        - "3.9"
         - "3.10"
+        - "3.11"
+        - "3.12"
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v23.1
+      uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
     - name: Run Check
-      uses: pre-commit/action@v3.0.0
+      uses: pre-commit/action@v3.0.1
       with:
         extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
     - name: Checks failed, notification
@@ -32,7 +32,7 @@ jobs:
         echo "pre-commit run --files ${{ steps.changed-files.outputs.all_changed_files }}"
     - name: Upload log artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: pre-commit-py${{ matrix.python-version }}
         path: /home/runner/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -12,16 +12,16 @@ jobs:
         - "3.12"
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5 
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
       with:
         python-version: ${{ matrix.python-version }}
     - name: Get changed files
       id: changed-files
       uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
     - name: Run Check
-      uses: pre-commit/action@v3.0.1
+      uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd
       with:
         extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
     - name: Checks failed, notification
@@ -32,7 +32,7 @@ jobs:
         echo "pre-commit run --files ${{ steps.changed-files.outputs.all_changed_files }}"
     - name: Upload log artifacts on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
       with:
         name: pre-commit-py${{ matrix.python-version }}
         path: /home/runner/.cache/pre-commit/pre-commit.log

--- a/.github/workflows/role-btrfs.yaml
+++ b/.github/workflows/role-btrfs.yaml
@@ -19,9 +19,9 @@ jobs:
         - 2drive-raid0
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-btrfs.yaml
+++ b/.github/workflows/role-btrfs.yaml
@@ -19,9 +19,9 @@ jobs:
         - 2drive-raid0
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-format.yaml
+++ b/.github/workflows/role-format.yaml
@@ -16,9 +16,9 @@ jobs:
         - format-xfs
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-format.yaml
+++ b/.github/workflows/role-format.yaml
@@ -16,9 +16,9 @@ jobs:
         - format-xfs
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-lvg.yaml
+++ b/.github/workflows/role-lvg.yaml
@@ -16,9 +16,9 @@ jobs:
         - 1drive
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-lvg.yaml
+++ b/.github/workflows/role-lvg.yaml
@@ -16,9 +16,9 @@ jobs:
         - 1drive
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-mdadm.yaml
+++ b/.github/workflows/role-mdadm.yaml
@@ -18,9 +18,9 @@ jobs:
         - 4drive-raid10
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-mdadm.yaml
+++ b/.github/workflows/role-mdadm.yaml
@@ -18,9 +18,9 @@ jobs:
         - 4drive-raid10
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-zfs_pool.yaml
+++ b/.github/workflows/role-zfs_pool.yaml
@@ -20,9 +20,9 @@ jobs:
         - 4drive-raidz
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-zfs_pool.yaml
+++ b/.github/workflows/role-zfs_pool.yaml
@@ -20,9 +20,9 @@ jobs:
         - 4drive-raidz
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-zfs_setup.yaml
+++ b/.github/workflows/role-zfs_setup.yaml
@@ -19,9 +19,9 @@ jobs:
         - default
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v5
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Set up Python
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/.github/workflows/role-zfs_setup.yaml
+++ b/.github/workflows/role-zfs_setup.yaml
@@ -19,9 +19,9 @@ jobs:
         - default
     steps:
     - name: Check out the repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v6
     - name: Install ansible-core
       run: |
         python -m pip install --upgrade pip wheel

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: cloudnull
 name: filesystems
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.0.4.1
+version: 0.0.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/format/tasks/main.yml
+++ b/roles/format/tasks/main.yml
@@ -5,7 +5,7 @@
     opts: "{{ format_options | default(omit) }}"
     dev: "{{ format_device }}"
   when:
-    - format_fileystem != "none"
+    - format_filesystem != "none"
 
 - name: Mount block
   when:


### PR DESCRIPTION
## Summary
Pins all GitHub Actions in workflows to full 40-character commit SHAs instead of version tags, and uses the internal figment-github-actions reusable pre-commit workflow (also pinned by SHA).

## Motivation
- Improves supply-chain security by using immutable refs.
- Aligns with GitHub’s recommendation and policy for SHA pinning.
- Reduces risk of tag mutability or compromised tags.
- Centralizes pre-commit logic in org-standard figment-github-actions.

## Changes

### Pre-commit workflow
- Replaced inline steps with internal reusable workflow: `figment-networks/figment-github-actions/.github/workflows/pre-commit.yaml@89b46e3bd29417a8c1a9129f0a200f63bf98b7e2`
- That workflow already uses pinned actions (checkout, setup-python, changed-files, pre-commit/action, upload-artifact).

### Other workflows (inline pins)
- **actions/checkout** `@v5` → `08c6903cd8c0fde910a37f88322edcfb5dd907a8`
- **actions/setup-python** `@v6` → `e797f83bcb11b83ae66e0230d6156d7c80228e7c`

## Files updated
- `.github/workflows/pre-commit.yaml` (now calls internal reusable workflow with SHA pin)
- `.github/workflows/role-btrfs.yaml`
- `.github/workflows/role-format.yaml`
- `.github/workflows/role-lvg.yaml`
- `.github/workflows/role-mdadm.yaml`
- `.github/workflows/role-zfs_pool.yaml`
- `.github/workflows/role-zfs_setup.yaml`